### PR TITLE
add go samples

### DIFF
--- a/bin/go.bash
+++ b/bin/go.bash
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+
+if [ -z $GOOGLEAPIS ]; then
+	echo >&2 "need GOOGLEAPIS variable pointed to a copy of master branch of https://github.com/googleapis/googleapis"
+	exit 1
+fi
+
+if [ -z $COMMON_PROTO ]; then
+	echo >&2 "need COMMON_PROTO variable pointed to a copy of https://github.com/googleapis/api-common-protos"
+	exit 1
+fi
+
+if ! which gen-go-sample > /dev/null; then
+	cat >&2 <<EOF
+need gen-go-sample binary:
+download https://github.com/googleapis/gapic-generator-go
+$ cd gapic-generator-go
+$ go install ./cmd/gen-go-sample
+EOF
+	exit 1
+fi
+
+# Paging methods don't work yet
+#
+# gen-go-sample \
+#   -clientpkg 'cloud.google.com/go/dialogflow/apiv2;dialogflow' \
+#   -gapic gapic_configs/dialogflow/v2/dialogflow_gapic.yaml \
+#   -o dialogflow/v2/go \
+#   -desc <(protoc -o /dev/stdout --include_imports -I "$COMMON_PROTO" -I "$GOOGLEAPIS" "$GOOGLEAPIS"/google/cloud/dialogflow/v2/*.proto)
+
+
+# Arrays don't work yet
+#
+# gen-go-sample \
+#   -clientpkg 'cloud.google.com/go/dlp/apiv2;dlp' \
+#   -gapic gapic_configs/dlp/v2/dlp_gapic.yaml \
+#   -o dlp/v2/go \
+#   -desc <(protoc -o /dev/stdout --include_imports -I "$COMMON_PROTO" -I "$GOOGLEAPIS" "$GOOGLEAPIS"/google/privacy/dlp/v2/*.proto)
+
+# Bug: nested message types don't work
+#
+# gen-go-sample \
+#   -clientpkg 'cloud.google.com/go/kms/apiv1;kms' \
+#   -gapic gapic_configs/kms/v1/cloudkms_gapic.yaml \
+#   -o kms/v1/go \
+#   -desc <(protoc -o /dev/stdout --include_imports -I "$COMMON_PROTO" -I "$GOOGLEAPIS" "$GOOGLEAPIS"/google/cloud/kms/v1/*.proto)
+
+gen-go-sample \
+  -clientpkg 'cloud.google.com/go/language/apiv1;language' \
+  -gapic gapic_configs/language/v1/language_gapic.yaml \
+  -o language/v1/go \
+  -desc <(protoc -o /dev/stdout --include_imports -I "$COMMON_PROTO" -I "$GOOGLEAPIS" "$GOOGLEAPIS"/google/cloud/language/v1/*.proto)
+
+gen-go-sample \
+  -clientpkg 'cloud.google.com/go/speech/apiv1;speech' \
+  -gapic gapic_configs/speech/v1/cloud_speech_gapic.yaml \
+  -o speech/v1/go \
+  -desc <(protoc -o /dev/stdout --include_imports -I "$COMMON_PROTO" -I "$GOOGLEAPIS" "$GOOGLEAPIS"/google/cloud/speech/v1/*.proto)
+
+cat >&2 <<'EOF'
+done generating; to test compile:
+find -name '*.go' | xargs -P $(nproc) -IF go build -o /dev/null F
+EOF

--- a/bin/go.bash
+++ b/bin/go.bash
@@ -39,13 +39,11 @@ fi
 #   -o dlp/v2/go \
 #   -desc <(protoc -o /dev/stdout --include_imports -I "$COMMON_PROTO" -I "$GOOGLEAPIS" "$GOOGLEAPIS"/google/privacy/dlp/v2/*.proto)
 
-# Bug: nested message types don't work
-#
-# gen-go-sample \
-#   -clientpkg 'cloud.google.com/go/kms/apiv1;kms' \
-#   -gapic gapic_configs/kms/v1/cloudkms_gapic.yaml \
-#   -o kms/v1/go \
-#   -desc <(protoc -o /dev/stdout --include_imports -I "$COMMON_PROTO" -I "$GOOGLEAPIS" "$GOOGLEAPIS"/google/cloud/kms/v1/*.proto)
+gen-go-sample \
+  -clientpkg 'cloud.google.com/go/kms/apiv1;kms' \
+  -gapic gapic_configs/kms/v1/cloudkms_gapic.yaml \
+  -o kms/v1/go \
+  -desc <(protoc -o /dev/stdout --include_imports -I "$COMMON_PROTO" -I "$GOOGLEAPIS" "$GOOGLEAPIS"/google/cloud/kms/v1/*.proto)
 
 gen-go-sample \
   -clientpkg 'cloud.google.com/go/language/apiv1;language' \

--- a/gapic_configs/dialogflow/v2/dialogflow_gapic.yaml
+++ b/gapic_configs/dialogflow/v2/dialogflow_gapic.yaml
@@ -477,7 +477,7 @@ interfaces:
     samples:
       standalone:
       - calling_forms: ".*"
-        value_sets: dialogflow_list_entity_types
+        value_sets: [dialogflow_list_entity_types]
         region_tag: dialogflow_list_entity_types
     sample_value_sets:
     - id: dialogflow_list_entity_types
@@ -544,7 +544,7 @@ interfaces:
     samples:
       standalone:
       - calling_forms: ".*"
-        value_sets: dialogflow_create_entity_type
+        value_sets: [dialogflow_create_entity_type]
         region_tag: dialogflow_create_entity_type
     sample_value_sets:
     - id: dialogflow_create_entity_type
@@ -598,7 +598,7 @@ interfaces:
     samples:
       standalone:
       - calling_forms: ".*"
-        value_sets: dialogflow_delete_entity_type
+        value_sets: [dialogflow_delete_entity_type]
         region_tag: dialogflow_delete_entity_type
     sample_value_sets:
     - id: dialogflow_delete_entity_type

--- a/gapic_configs/dlp/v2/dlp_gapic.yaml
+++ b/gapic_configs/dlp/v2/dlp_gapic.yaml
@@ -146,7 +146,7 @@ interfaces:
     samples:
       standalone:
       - calling_forms: ".*"
-        value_sets: dlp_inspect_string
+        value_sets: [dlp_inspect_string]
         region_tag: dlp_inspect_string
     sample_value_sets:
     - id: dlp_inspect_string

--- a/gapic_configs/kms/v1/cloudkms_gapic.yaml
+++ b/gapic_configs/kms/v1/cloudkms_gapic.yaml
@@ -251,11 +251,11 @@ interfaces:
 
     ###
     #
-    
+
     samples:
       standalone:
       - calling_forms: ".*"
-        value_sets: kms_create_key_ring
+        value_sets: [kms_create_key_ring]
         region_tag: kms_create_key_ring
 
     sample_value_sets:

--- a/gapic_configs/kms/v1/cloudkms_gapic.yaml
+++ b/gapic_configs/kms/v1/cloudkms_gapic.yaml
@@ -264,6 +264,8 @@ interfaces:
       description: "Create a KeyRing"
       parameters:
       ####   defaults:
+        defaults:
+          - key_ring_id="the id"
         attributes:
         - parameter: key_ring_id
           sample_argument: true

--- a/gapic_configs/language/v1/language_gapic.yaml
+++ b/gapic_configs/language/v1/language_gapic.yaml
@@ -62,10 +62,10 @@ interfaces:
     samples:
       standalone:
       - calling_forms: ".*"
-        value_sets: language_sentiment_text
+        value_sets: [language_sentiment_text]
         region_tag: language_sentiment_text
       - calling_forms: ".*"
-        value_sets: language_sentiment_gcs
+        value_sets: [language_sentiment_gcs]
         region_tag: language_sentiment_gcs
 
     sample_value_sets:
@@ -122,10 +122,10 @@ interfaces:
     samples:
       standalone:
       - calling_forms: ".*"
-        value_sets: language_entities_text
+        value_sets: [language_entities_text]
         region_tag: language_entities_text
       - calling_forms: ".*"
-        value_sets: language_entities_gcs
+        value_sets: [language_entities_gcs]
         region_tag: language_entities_gcs
 
     sample_value_sets:
@@ -209,10 +209,10 @@ interfaces:
     samples:
        standalone:
        - calling_forms: ".*"
-         value_sets: language_syntax_text
+         value_sets: [language_syntax_text]
          region_tag: language_syntax_text
        - calling_forms: ".*"
-         value_sets: language_syntax_gcs
+         value_sets: [language_syntax_gcs]
          region_tag: language_syntax_gcs
 
     sample_value_sets:

--- a/gapic_configs/speech/v1/cloud_speech_gapic.yaml
+++ b/gapic_configs/speech/v1/cloud_speech_gapic.yaml
@@ -69,7 +69,7 @@ interfaces:
     samples:
       standalone:
       - calling_forms: ".*"
-        value_sets: speech_transcribe_sync_gcs
+        value_sets: [speech_transcribe_sync_gcs]
         region_tag: speech_transcribe_sync_gcs
     sample_value_sets:
     - id: speech_transcribe_sync_gcs

--- a/kms/v1/go/google.cloud.kms.v1.KeyManagementService_CreateKeyRing_kms_create_key_ring.go
+++ b/kms/v1/go/google.cloud.kms.v1.KeyManagementService_CreateKeyRing_kms_create_key_ring.go
@@ -22,47 +22,38 @@ import (
 	"fmt"
 	"log"
 
-	language "cloud.google.com/go/language/apiv1"
-	languagepb "google.golang.org/genproto/googleapis/cloud/language/v1"
+	kms "cloud.google.com/go/kms/apiv1"
+	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
 )
 
-// [START language_syntax_text]
+// [START kms_create_key_ring]
 
-func sampleAnalyzeSyntax(arg0 string) error {
+func sampleCreateKeyRing(arg0 string) error {
 	ctx := context.Background()
-	c, err := language.NewClient(ctx)
+	c, err := kms.NewKeyManagementClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	// arg0 := "Your text to analyze, e.g. Hello, world!"
-	req := &languagepb.AnalyzeSyntaxRequest{
-		Document: &languagepb.Document{
-			Type: languagepb.Document_PLAIN_TEXT,
-			Source: &languagepb.Document_Content{
-				Content: arg0,
-			},
-		},
+	// arg0 := "the id"
+	req := &kmspb.CreateKeyRingRequest{
+		KeyRingId: arg0,
 	}
-	resp, err := c.AnalyzeSyntax(ctx, req)
+	resp, err := c.CreateKeyRing(ctx, req)
 	if err != nil {
 		return err
 	}
 
-	tokens := resp.GetTokens()
-	for _, token := range tokens {
-		fmt.Printf("Part of speech: %v\n", token.GetPartOfSpeech().GetTag())
-		fmt.Printf("Text:\n", token.GetText())
-	}
+	fmt.Printf("Name: %v\n", resp.GetName())
 	return nil
 }
 
-// [END language_syntax_text]
+// [END kms_create_key_ring]
 
 func main() {
-	arg0 := flag.String("arg0", "Your text to analyze, e.g. Hello, world!", "")
+	arg0 := flag.String("arg0", "the id", "")
 	flag.Parse()
-	if err := sampleAnalyzeSyntax(*arg0); err != nil {
+	if err := sampleCreateKeyRing(*arg0); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeEntities_language_entities_gcs.go
+++ b/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeEntities_language_entities_gcs.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log"
 
 	language "cloud.google.com/go/language/apiv1"
 	languagepb "google.golang.org/genproto/googleapis/cloud/language/v1"
@@ -61,5 +62,7 @@ func sampleAnalyzeEntities(arg0 string) error {
 func main() {
 	arg0 := flag.String("arg0", "Path to text file, e.g. gs://my-bucket/textfile", "")
 	flag.Parse()
-	sampleAnalyzeEntities(*arg0)
+	if err := sampleAnalyzeEntities(*arg0); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeEntities_language_entities_gcs.go
+++ b/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeEntities_language_entities_gcs.go
@@ -1,0 +1,65 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// AUTO-GENERATED CODE. DO NOT EDIT.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	language "cloud.google.com/go/language/apiv1"
+	languagepb "google.golang.org/genproto/googleapis/cloud/language/v1"
+)
+
+// [START language_entities_gcs]
+
+func sampleAnalyzeEntities(arg0 string) error {
+	ctx := context.Background()
+	c, err := language.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// arg0 := "Path to text file, e.g. gs://my-bucket/textfile"
+	req := &languagepb.AnalyzeEntitiesRequest{
+		Document: &languagepb.Document{
+			Type: languagepb.Document_PLAIN_TEXT,
+			Source: &languagepb.Document_GcsContentUri{
+				GcsContentUri: arg0,
+			},
+		},
+	}
+	resp, err := c.AnalyzeEntities(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	entities := resp.GetEntities()
+	for _, entity := range entities {
+		fmt.Printf("Entity name: %v\n", entity.GetName())
+		fmt.Printf("Entity type: %v\n", entity.GetType())
+	}
+	return nil
+}
+
+// [END language_entities_gcs]
+
+func main() {
+	arg0 := flag.String("arg0", "Path to text file, e.g. gs://my-bucket/textfile", "")
+	flag.Parse()
+	sampleAnalyzeEntities(*arg0)
+}

--- a/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeEntities_language_entities_text.go
+++ b/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeEntities_language_entities_text.go
@@ -1,0 +1,65 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// AUTO-GENERATED CODE. DO NOT EDIT.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	language "cloud.google.com/go/language/apiv1"
+	languagepb "google.golang.org/genproto/googleapis/cloud/language/v1"
+)
+
+// [START language_entities_text]
+
+func sampleAnalyzeEntities(arg0 string) error {
+	ctx := context.Background()
+	c, err := language.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// arg0 := "Your text to analyze, e.g. Hello, world!"
+	req := &languagepb.AnalyzeEntitiesRequest{
+		Document: &languagepb.Document{
+			Type: languagepb.Document_PLAIN_TEXT,
+			Source: &languagepb.Document_Content{
+				Content: arg0,
+			},
+		},
+	}
+	resp, err := c.AnalyzeEntities(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	entities := resp.GetEntities()
+	for _, entity := range entities {
+		fmt.Printf("Entity name: %v\n", entity.GetName())
+		fmt.Printf("Entity type: %v\n", entity.GetType())
+	}
+	return nil
+}
+
+// [END language_entities_text]
+
+func main() {
+	arg0 := flag.String("arg0", "Your text to analyze, e.g. Hello, world!", "")
+	flag.Parse()
+	sampleAnalyzeEntities(*arg0)
+}

--- a/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeEntities_language_entities_text.go
+++ b/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeEntities_language_entities_text.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log"
 
 	language "cloud.google.com/go/language/apiv1"
 	languagepb "google.golang.org/genproto/googleapis/cloud/language/v1"
@@ -61,5 +62,7 @@ func sampleAnalyzeEntities(arg0 string) error {
 func main() {
 	arg0 := flag.String("arg0", "Your text to analyze, e.g. Hello, world!", "")
 	flag.Parse()
-	sampleAnalyzeEntities(*arg0)
+	if err := sampleAnalyzeEntities(*arg0); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeSentiment_language_sentiment_gcs.go
+++ b/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeSentiment_language_sentiment_gcs.go
@@ -1,0 +1,63 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// AUTO-GENERATED CODE. DO NOT EDIT.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	language "cloud.google.com/go/language/apiv1"
+	languagepb "google.golang.org/genproto/googleapis/cloud/language/v1"
+)
+
+// [START language_sentiment_gcs]
+
+func sampleAnalyzeSentiment(arg0 string) error {
+	ctx := context.Background()
+	c, err := language.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// arg0 := "Path to text file, e.g. gs://my-bucket/textfile"
+	req := &languagepb.AnalyzeSentimentRequest{
+		Document: &languagepb.Document{
+			Type: languagepb.Document_PLAIN_TEXT,
+			Source: &languagepb.Document_GcsContentUri{
+				GcsContentUri: arg0,
+			},
+		},
+	}
+	resp, err := c.AnalyzeSentiment(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	sentiment := resp.GetDocumentSentiment()
+	fmt.Printf("score: %v\n", sentiment.GetScore())
+	fmt.Printf("magnitude: %v\n", sentiment.GetMagnitude())
+	return nil
+}
+
+// [END language_sentiment_gcs]
+
+func main() {
+	arg0 := flag.String("arg0", "Path to text file, e.g. gs://my-bucket/textfile", "")
+	flag.Parse()
+	sampleAnalyzeSentiment(*arg0)
+}

--- a/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeSentiment_language_sentiment_gcs.go
+++ b/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeSentiment_language_sentiment_gcs.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log"
 
 	language "cloud.google.com/go/language/apiv1"
 	languagepb "google.golang.org/genproto/googleapis/cloud/language/v1"
@@ -59,5 +60,7 @@ func sampleAnalyzeSentiment(arg0 string) error {
 func main() {
 	arg0 := flag.String("arg0", "Path to text file, e.g. gs://my-bucket/textfile", "")
 	flag.Parse()
-	sampleAnalyzeSentiment(*arg0)
+	if err := sampleAnalyzeSentiment(*arg0); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeSentiment_language_sentiment_text.go
+++ b/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeSentiment_language_sentiment_text.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log"
 
 	language "cloud.google.com/go/language/apiv1"
 	languagepb "google.golang.org/genproto/googleapis/cloud/language/v1"
@@ -59,5 +60,7 @@ func sampleAnalyzeSentiment(arg0 string) error {
 func main() {
 	arg0 := flag.String("arg0", "Your text to analyze, e.g. Hello, world!", "")
 	flag.Parse()
-	sampleAnalyzeSentiment(*arg0)
+	if err := sampleAnalyzeSentiment(*arg0); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeSentiment_language_sentiment_text.go
+++ b/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeSentiment_language_sentiment_text.go
@@ -1,0 +1,63 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// AUTO-GENERATED CODE. DO NOT EDIT.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	language "cloud.google.com/go/language/apiv1"
+	languagepb "google.golang.org/genproto/googleapis/cloud/language/v1"
+)
+
+// [START language_sentiment_text]
+
+func sampleAnalyzeSentiment(arg0 string) error {
+	ctx := context.Background()
+	c, err := language.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// arg0 := "Your text to analyze, e.g. Hello, world!"
+	req := &languagepb.AnalyzeSentimentRequest{
+		Document: &languagepb.Document{
+			Type: languagepb.Document_PLAIN_TEXT,
+			Source: &languagepb.Document_Content{
+				Content: arg0,
+			},
+		},
+	}
+	resp, err := c.AnalyzeSentiment(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	sentiment := resp.GetDocumentSentiment()
+	fmt.Printf("score: %v\n", sentiment.GetScore())
+	fmt.Printf("magnitude: %v\n", sentiment.GetMagnitude())
+	return nil
+}
+
+// [END language_sentiment_text]
+
+func main() {
+	arg0 := flag.String("arg0", "Your text to analyze, e.g. Hello, world!", "")
+	flag.Parse()
+	sampleAnalyzeSentiment(*arg0)
+}

--- a/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeSyntax_language_syntax_gcs.go
+++ b/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeSyntax_language_syntax_gcs.go
@@ -1,0 +1,65 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// AUTO-GENERATED CODE. DO NOT EDIT.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	language "cloud.google.com/go/language/apiv1"
+	languagepb "google.golang.org/genproto/googleapis/cloud/language/v1"
+)
+
+// [START language_syntax_gcs]
+
+func sampleAnalyzeSyntax(arg0 string) error {
+	ctx := context.Background()
+	c, err := language.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// arg0 := "Path to text file, e.g. gs://my-bucket/textfile"
+	req := &languagepb.AnalyzeSyntaxRequest{
+		Document: &languagepb.Document{
+			Type: languagepb.Document_PLAIN_TEXT,
+			Source: &languagepb.Document_GcsContentUri{
+				GcsContentUri: arg0,
+			},
+		},
+	}
+	resp, err := c.AnalyzeSyntax(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	tokens := resp.GetTokens()
+	for _, token := range tokens {
+		fmt.Printf("Part of speech: %v\n", token.GetPartOfSpeech().GetTag())
+		fmt.Printf("Text:\n", token.GetText())
+	}
+	return nil
+}
+
+// [END language_syntax_gcs]
+
+func main() {
+	arg0 := flag.String("arg0", "Path to text file, e.g. gs://my-bucket/textfile", "")
+	flag.Parse()
+	sampleAnalyzeSyntax(*arg0)
+}

--- a/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeSyntax_language_syntax_gcs.go
+++ b/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeSyntax_language_syntax_gcs.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log"
 
 	language "cloud.google.com/go/language/apiv1"
 	languagepb "google.golang.org/genproto/googleapis/cloud/language/v1"
@@ -61,5 +62,7 @@ func sampleAnalyzeSyntax(arg0 string) error {
 func main() {
 	arg0 := flag.String("arg0", "Path to text file, e.g. gs://my-bucket/textfile", "")
 	flag.Parse()
-	sampleAnalyzeSyntax(*arg0)
+	if err := sampleAnalyzeSyntax(*arg0); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeSyntax_language_syntax_text.go
+++ b/language/v1/go/google.cloud.language.v1.LanguageService_AnalyzeSyntax_language_syntax_text.go
@@ -1,0 +1,65 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// AUTO-GENERATED CODE. DO NOT EDIT.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	language "cloud.google.com/go/language/apiv1"
+	languagepb "google.golang.org/genproto/googleapis/cloud/language/v1"
+)
+
+// [START language_syntax_text]
+
+func sampleAnalyzeSyntax(arg0 string) error {
+	ctx := context.Background()
+	c, err := language.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// arg0 := "Your text to analyze, e.g. Hello, world!"
+	req := &languagepb.AnalyzeSyntaxRequest{
+		Document: &languagepb.Document{
+			Type: languagepb.Document_PLAIN_TEXT,
+			Source: &languagepb.Document_Content{
+				Content: arg0,
+			},
+		},
+	}
+	resp, err := c.AnalyzeSyntax(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	tokens := resp.GetTokens()
+	for _, token := range tokens {
+		fmt.Printf("Part of speech: %v\n", token.GetPartOfSpeech().GetTag())
+		fmt.Printf("Text:\n", token.GetText())
+	}
+	return nil
+}
+
+// [END language_syntax_text]
+
+func main() {
+	arg0 := flag.String("arg0", "Your text to analyze, e.g. Hello, world!", "")
+	flag.Parse()
+	sampleAnalyzeSyntax(*arg0)
+}

--- a/speech/v1/go/google.cloud.speech.v1.Speech_Recognize_speech_transcribe_sync_gcs.go
+++ b/speech/v1/go/google.cloud.speech.v1.Speech_Recognize_speech_transcribe_sync_gcs.go
@@ -1,0 +1,69 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// AUTO-GENERATED CODE. DO NOT EDIT.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	speech "cloud.google.com/go/speech/apiv1"
+	speechpb "google.golang.org/genproto/googleapis/cloud/speech/v1"
+)
+
+// [START speech_transcribe_sync_gcs]
+
+func sampleRecognize(arg0 string) error {
+	ctx := context.Background()
+	c, err := speech.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// arg0 := "Path to audio file in GCS, e.g. gs://my-bucket/audio.wav"
+	req := &speechpb.RecognizeRequest{
+		Config: &speechpb.RecognitionConfig{
+			Encoding:        speechpb.RecognitionConfig_LINEAR16,
+			SampleRateHertz: 16000,
+			LanguageCode:    "en-US",
+		},
+		Audio: &speechpb.RecognitionAudio{
+			AudioSource: &speechpb.RecognitionAudio_Uri{
+				Uri: arg0,
+			},
+		},
+	}
+	resp, err := c.Recognize(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	for _, result := range resp.GetResults() {
+		for _, alternative := range result.GetAlternatives() {
+			fmt.Printf("Transcript: %v\n", alternative.GetTranscript())
+		}
+	}
+	return nil
+}
+
+// [END speech_transcribe_sync_gcs]
+
+func main() {
+	arg0 := flag.String("arg0", "Path to audio file in GCS, e.g. gs://my-bucket/audio.wav", "")
+	flag.Parse()
+	sampleRecognize(*arg0)
+}

--- a/speech/v1/go/google.cloud.speech.v1.Speech_Recognize_speech_transcribe_sync_gcs.go
+++ b/speech/v1/go/google.cloud.speech.v1.Speech_Recognize_speech_transcribe_sync_gcs.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log"
 
 	speech "cloud.google.com/go/speech/apiv1"
 	speechpb "google.golang.org/genproto/googleapis/cloud/speech/v1"
@@ -65,5 +66,7 @@ func sampleRecognize(arg0 string) error {
 func main() {
 	arg0 := flag.String("arg0", "Path to audio file in GCS, e.g. gs://my-bucket/audio.wav", "")
 	flag.Parse()
-	sampleRecognize(*arg0)
+	if err := sampleRecognize(*arg0); err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
We add square brackets to yaml. Go YAML library is more strict; it won't accept a string where it expects a string array.